### PR TITLE
Modified to xpath exist in get_xpath_attribute

### DIFF
--- a/lib/xpage.rb
+++ b/lib/xpage.rb
@@ -28,7 +28,7 @@ class Xpage
   end
   
   def get_xpath_attribute(xpath, attribute)
-    wait_for_xpath_to_display xpath
+    wait_for_xpath_to_exist xpath
 
     @@retryer.do(description: 'get_xpath_attribute') {
       element = get_element xpath


### PR DESCRIPTION
Modified the check for xpath displayed to xpath exist in get_xpath_attribute, as it would allow to get the attribute even if its not visibile eg. style = 'display: none'